### PR TITLE
Feature/add check for one word line

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,13 +51,9 @@ function shrinkToFit(text, widthPx, settings) {
       }
     });
 
-  function checkHeight(size) {
-    let heightMax = size;
-    for (let i = 2; i < words.length + 1; i += 1)
-      if (words.every((w) => w.length) && words.length === i && size * i > heightPx)
-        heightMax = heightPx / i;
-    return heightMax;
-  }
+    function checkHeight(size) {
+      return size * words.length > heightPx ? size / words.length : size;
+    }
 
   fontSizeLoop: for (let fontSize = startingSizePx; fontSize > minSizePx; fontSize -= 1) {
     let numLines = 1;

--- a/index.js
+++ b/index.js
@@ -1,5 +1,3 @@
-'use strict';
-
 module.exports = shrinkToFit;
 
 /**
@@ -17,42 +15,38 @@ module.exports = shrinkToFit;
  * @returns {number} The font size (in px) to display.
  */
 function shrinkToFit(text, widthPx, settings) {
-    var defaults = {
+    const defaults = {
         maxLines: 2,
         fontFamily: "sans-serif",
         startingSizePx: 90,
         minSizePx: 30
     };
-    var settings = Object.assign({}, defaults, settings);
+    const { startingSizePx, fontFamily, minSizePx, maxLines } = { ...defaults, ...settings };
 
     if (!text || !text.length) return text;
-    if (!widthPx) return settings.startingSizePx;
+    if (!widthPx) return startingSizePx;
 
     // intentionally matching on \s and not on \b because we want non-whitespace word
     // boundaries to stay on the same line as the previous word.
-    var words = text.split(/\s+/g),
-        canvas = document.createElement('canvas'),
-        canvasContext = canvas.getContext('2d');
-    fontSizeLoop:
-    for (var fontSize = settings.startingSizePx; fontSize > settings.minSizePx; fontSize--) {
-        var numLines = 1;
-        canvasContext.font = fontSize + 'px ' + settings.fontFamily;
-        var textBuffer = "";
-        lineWrapLoop:
-        for (var wordIndex = 0; wordIndex < words.length; wordIndex++) {
-            textBuffer += " " + words[wordIndex];
-            var bufferWidth = canvasContext.measureText(textBuffer.trim()).width;
+    const words = text.split(/\s+/g);
+    const canvas = document.createElement('canvas');
+    const canvasContext = canvas.getContext('2d');
+    fontSizeLoop: for (let fontSize = startingSizePx; fontSize > minSizePx; fontSize -= 1) {
+          let numLines = 1;
+          canvasContext.font = `${fontSize}px ${fontFamily}`;
+          let textBuffer = '';
+          for (let wordIndex = 0; wordIndex < words.length; wordIndex += 1) {
+            textBuffer += ` ${words[wordIndex]}`;
+            const bufferWidth = canvasContext.measureText(textBuffer.trim()).width;
             if (bufferWidth > widthPx) {
-                numLines++;
-                if (numLines > settings.maxLines) {
-                    continue fontSizeLoop;
-                }
-                // wrap this word to the next line since it didn't fit.
-                textBuffer = words[wordIndex];
+              numLines += 1;
+              if (numLines > maxLines) continue fontSizeLoop;
+              // wrap this word to the next line since it didn't fit.
+              textBuffer = words[wordIndex];
             }
+          }
+          return fontSize;
         }
-        return fontSize;
-    }
-    // font size values > minSize exhausted.
-    return settings.minSizePx;
+        // font size values > minSize exhausted.
+        return minSizePx;
 }

--- a/index.js
+++ b/index.js
@@ -12,59 +12,70 @@ module.exports = shrinkToFit;
  * @param {number} [settings.startingSizePx=90] Starting font size (in px) to use.
  * @param {number} [settings.minSizePx=30] Minimum font size (in px) to drop to.  Takes higher priority than maxLines -- i.e. if text can't fit on maxLines lines at minSize, it'll return at minSize anyway.
  * @param {bool} [settings.oneWordLineCheck=false] In some cases, where width is particularly small, it is necessary to account for the size of the largest word in the entire text string. This is a performance hit.
+ * @param {number} [settings.heightPx=0] In some cases, where width is particularly small, and height is limited, there can be top or bottom overflow. Setting a height here will limit maximun returned height to (heightPx / word count)
  * @returns {number} The font size (in px) to display.
  */
 function shrinkToFit(text, widthPx, settings) {
-    const defaults = {
-        maxLines: 2,
-        fontFamily: "sans-serif",
-        startingSizePx: 90,
-        minSizePx: 30,
-        oneWordLineCheck: false
-    };
-    const { startingSizePx, fontFamily, minSizePx, maxLines, oneWordLineCheck } = {
-      ...defaults,
-      ...settings,
-    };
+  const defaults = {
+    maxLines: 2,
+    fontFamily: 'sans-serif',
+    startingSizePx: 90,
+    minSizePx: 30,
+    oneWordLineCheck: false,
+    heightPx: 0,
+  };
+  const { startingSizePx, fontFamily, minSizePx, maxLines, oneWordLineCheck, heightPx } = {
+    ...defaults,
+    ...settings,
+  };
 
-    if (!text || !text.length) return text;
-    if (!widthPx) return startingSizePx;
+  if (!text || !text.length) return text;
+  if (!widthPx) return startingSizePx;
 
-    // intentionally matching on \s and not on \b because we want non-whitespace word
-    // boundaries to stay on the same line as the previous word.
-    const words = text.trim().split(/\s+/g);
-    const canvas = document.createElement('canvas');
-    const canvasContext = canvas.getContext('2d');
+  // intentionally matching on \s and not on \b because we want non-whitespace word
+  // boundaries to stay on the same line as the previous word.
+  const words = text.trim().split(/\s+/g);
+  const canvas = document.createElement('canvas');
+  const canvasContext = canvas.getContext('2d');
 
-    let fontSizeMaximum = 1000;
-    if (oneWordLineCheck)
-      words.forEach((word) => {
-        if (word.length > 0) {
-          let i = 0;
-          do {
-            i += 1;
-            canvasContext.font = `${i}px ${fontFamily}`;
-          } while (canvasContext.measureText(word.trim()).width < widthPx);
-          if (i < fontSizeMaximum) fontSizeMaximum = i;
-        }
-      });
+  let fontSizeMaximum = 1000;
+  if (oneWordLineCheck)
+    words.forEach((word) => {
+      if (word.length > 0) {
+        let i = 0;
+        do {
+          i += 1;
+          canvasContext.font = `${i}px ${fontFamily}`;
+        } while (canvasContext.measureText(word.trim()).width < widthPx);
+        if (i < fontSizeMaximum) fontSizeMaximum = i;
+      }
+    });
 
-    fontSizeLoop: for (let fontSize = startingSizePx; fontSize > minSizePx; fontSize -= 1) {
-          let numLines = 1;
-          canvasContext.font = `${fontSize}px ${fontFamily}`;
-          let textBuffer = '';
-          for (let wordIndex = 0; wordIndex < words.length; wordIndex += 1) {
-            textBuffer += ` ${words[wordIndex]}`;
-            const bufferWidth = canvasContext.measureText(textBuffer.trim()).width;
-            if (bufferWidth > widthPx) {
-              numLines += 1;
-              if (numLines > maxLines) continue fontSizeLoop;
-              // wrap this word to the next line since it didn't fit.
-              textBuffer = words[wordIndex];
-            }
-          }
-          return Math.min(fontSize, fontSizeMaximum);
-        }
-        // font size values > minSize exhausted.
-        return minSizePx;
+  function checkHeight(size) {
+    let heightMax = size;
+    for (let i = 2; i < words.length + 1; i += 1)
+      if (words.every((w) => w.length) && words.length === i && size * i > heightPx)
+        heightMax = heightPx / i;
+    return heightMax;
+  }
+
+  fontSizeLoop: for (let fontSize = startingSizePx; fontSize > minSizePx; fontSize -= 1) {
+    let numLines = 1;
+    canvasContext.font = `${fontSize}px ${fontFamily}`;
+    let textBuffer = '';
+    for (let wordIndex = 0; wordIndex < words.length; wordIndex += 1) {
+      textBuffer += ` ${words[wordIndex]}`;
+      const bufferWidth = canvasContext.measureText(textBuffer.trim()).width;
+      if (bufferWidth > widthPx) {
+        numLines += 1;
+        if (numLines > maxLines) continue fontSizeLoop;
+        // wrap this word to the next line since it didn't fit.
+        textBuffer = words[wordIndex];
+      }
+    }
+    const finalSize = Math.min(fontSize, fontSizeMaximum);
+    return heightPx !== 0 ? checkHeight(finalSize) : finalSize;
+  }
+  // font size values > minSize exhausted.
+  return minSizePx;
 }

--- a/index.js
+++ b/index.js
@@ -10,9 +10,8 @@ module.exports = shrinkToFit;
  * @param {number} [settings.maxLines=2] Maximum number of lines to which text should wrap.
  * @param {string} [settings.fontFamily="sans serif"] Font face/family to use.
  * @param {number} [settings.startingSizePx=90] Starting font size (in px) to use.
- * @param {number} [settings.minSizePx=30] Minimum font size (in px) to drop to.  Takes higher priority
+ * @param {number} [settings.minSizePx=30] Minimum font size (in px) to drop to.  Takes higher priority than maxLines -- i.e. if text can't fit on maxLines lines at minSize, it'll return at minSize anyway.
  * @param {bool} [settings.oneWordLineCheck=false] In some cases, where width is particularly small, it is necessary to account for the size of the largest word in the entire text string. This is a performance hit.
- * than maxLines -- i.e. if text can't fit on maxLines lines at minSize, it'll return at minSize anyway.
  * @returns {number} The font size (in px) to display.
  */
 function shrinkToFit(text, widthPx, settings) {


### PR DESCRIPTION
- Modernize JS (+semver:fix)
- Fix a bug by adding `trim()` to the text to prevent trailing space being counted as a word (+semver:fix)
- Add a setting to check for one word lines  (+semver:feature)
- Add a setting to check for very thin width containers forced to overflow top and/or bottom  (+semver:feature)
